### PR TITLE
Fix jittering while standing on a turning train

### DIFF
--- a/common/src/main/java/net/derfruhling/minecraft/create/trainperspective/mixin/LocalPlayerMixin.java
+++ b/common/src/main/java/net/derfruhling/minecraft/create/trainperspective/mixin/LocalPlayerMixin.java
@@ -1,0 +1,29 @@
+package net.derfruhling.minecraft.create.trainperspective.mixin;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.player.LocalPlayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+// If anything else tries to @Overwrite getViewYRot, use their changes.
+@Mixin(value = LocalPlayer.class, priority = 200)
+public class LocalPlayerMixin extends AbstractClientPlayer {
+    private LocalPlayerMixin(ClientLevel clientLevel, GameProfile gameProfile) {
+        super(clientLevel, gameProfile);
+    }
+
+    /**
+     * @author der_frühling
+     * @reason Mojang, for some reason, is not using the value of getViewYRot unless
+     * the player is a passenger.
+     * This breaks yaw while standing on a train.
+     * This is an {@link Overwrite @Overwrite} method because of the small
+     * size of the target method and the simple fix it needs to apply.
+     */
+    @Overwrite
+    public float getViewYRot(float f) {
+        return super.getViewYRot(f);
+    }
+}

--- a/common/src/main/resources/create_train_perspective.mixins.json
+++ b/common/src/main/resources/create_train_perspective.mixins.json
@@ -8,9 +8,14 @@
     "AbstractContraptionEntityMixin",
     "EntityMixin",
     "GameRendererMixin",
+    "LocalPlayerMixin",
     "PlayerRendererMixin",
     "CreateRaycastHelperMixin"
   ],
+  "overwrites": {
+    "requireAnnotations": true,
+    "conformVisibility": true
+  },
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
Resolves #47

Resolved with a method overwrite in LocalPlayer. Mojang (for some reason) overrides getViewYRot() to return getYRot() if the player is not a passenger.

Compatibility of this change is yet to be determined.
