### PR TITLE
Compatibility: Figura

### DIFF
--- a/common/src/main/java/net/derfruhling/minecraft/create/trainperspective/mixin/CameraMixin.java
+++ b/common/src/main/java/net/derfruhling/minecraft/create/trainperspective/mixin/CameraMixin.java
@@ -10,6 +10,7 @@ import net.minecraft.client.player.AbstractClientPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.BlockGetter;
 import org.joml.Quaternionf;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
@@ -49,8 +50,11 @@ public abstract class CameraMixin {
     public void modifyRotations(Camera instance,
                                 float y,
                                 float x,
-                                @Local(argsOnly = true, ordinal = 0) boolean isThirdPerson,
-                                @Local(argsOnly = true) float f) {
+                                BlockGetter blockGetter,
+                                Entity entity,
+                                boolean isThirdPerson,
+                                boolean bl2,
+                                float f) {
         if(entity instanceof AbstractClientPlayer player
            && Conditional.shouldApplyPerspectiveTo(entity)
            && Conditional.shouldApplyLeaning()
@@ -81,8 +85,11 @@ public abstract class CameraMixin {
                                double x,
                                double y,
                                double z,
-                               @Local(argsOnly = true, ordinal = 0) boolean isThirdPerson,
-                               @Local(argsOnly = true) float f) {
+                               BlockGetter blockGetter,
+                               Entity entity,
+                               boolean isThirdPerson,
+                               boolean bl2,
+                               float f) {
         if(entity instanceof AbstractClientPlayer player
                 && Conditional.shouldApplyPerspectiveTo(entity)
                 && Conditional.shouldApplyLeaning()


### PR DESCRIPTION
Something about these two mods change the LVT of a method, making them incompatible. This change uses the full args list on that method instead of selectively looking for local variables.

Fixes #58